### PR TITLE
feat(packages): add opencode

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -14,4 +14,5 @@
     - sketchybar
     - starship
     - package_management
+    - opencode
     - volta

--- a/roles/opencode/files/opencode.jsonc
+++ b/roles/opencode/files/opencode.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "theme": "system",
+}

--- a/roles/opencode/tasks/main.yml
+++ b/roles/opencode/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Setup opencode config
+  ansible.builtin.file:
+    src: "{{ role_path }}/files"
+    dest: ~/.config/opencode
+    mode: u=rwx,go=r
+    state: link

--- a/roles/package_management/vars/main.yml
+++ b/roles/package_management/vars/main.yml
@@ -26,6 +26,7 @@ brew_formula_packages:
   - nushell
   - openssh
   - ripgrep
+  - sst/tap/opencode
   - tldr
   - tmux
   - tursodatabase/tap/turso
@@ -41,6 +42,7 @@ arch_packages:
   - aur/graphite-cli-git
   - aur/mailspring-bin
   - aur/onlyoffice-bin
+  - aur/opencode-bin
   - aur/standardnotes-bin
   - aur/turso-cli-bin
   - aur/volta-bin


### PR DESCRIPTION
### TL;DR

Added OpenCode AI to the development environment setup.

### What changed?

- Added OpenCode to the main Ansible playbook
- Created a new OpenCode role with configuration files
- Added OpenCode to package installation lists for both Homebrew and Arch Linux

### How to test?

1. Run the updated Ansible playbook
2. Verify OpenCode is installed via `opencode --version`
3. Check that the configuration is properly linked at `~/.config/opencode`
4. Launch OpenCode and confirm it uses the system theme

### Why make this change?

Integrating OpenCode AI into the development environment provides a consistent AI coding assistant across different machines. The system theme configuration ensures it matches the user's preferred appearance settings.