### PR TITLE
fix(python): use conda python systemwide

### DIFF
--- a/roles/zsh/files/zsh/.zprofile
+++ b/roles/zsh/files/zsh/.zprofile
@@ -20,6 +20,8 @@ export CXXFLAGS="-stdlib=libc++"
 
 export EDITOR="nvim"
 
+export PYTHON="/opt/homebrew/Caskroom/miniconda/base/bin/python"
+
 export GIT_CONFIG_SYSTEM="$XDG_CONFIG_HOME/git/.gitconfig"
 export STARSHIP_CONFIG="$XDG_CONFIG_HOME/starship/starship.toml"
 


### PR DESCRIPTION
### TL;DR

Added PYTHON environment variable pointing to Miniconda Python installation.

### What changed?

Added a new environment variable `PYTHON` in the `.zprofile` file that points to the Python executable located in the Miniconda installation directory (`/opt/homebrew/Caskroom/miniconda/base/bin/python`).

### How to test?

1. Source the updated `.zprofile` file or restart your shell
2. Verify the environment variable is set correctly by running `echo $PYTHON`
3. Confirm the path exists and is executable by running `$PYTHON --version`

### Why make this change?

This change ensures that scripts or applications that rely on the `PYTHON` environment variable will consistently use the Miniconda Python installation rather than any system or other Python versions that might be installed. This helps maintain a consistent Python environment across different tools and scripts.