### PR TITLE
chore(packages): update package names to be current since some of them have changed and that caused errors.

### DIFF
--- a/roles/package_management/vars/main.yml
+++ b/roles/package_management/vars/main.yml
@@ -3,23 +3,21 @@ brew_formula_packages:
   - fd
   - felixkratz/formulae/sketchybar
   - go-task/tap/go-task
-  - homebrew/cask-fonts/font-jetbrains-mono
-  - homebrew/cask-fonts/font-jetbrains-mono-nerd-font
   - homebrew/cask/anytype
   - homebrew/cask/brave-browser
   - homebrew/cask/discord
-  - homebrew/cask/emacs
   - homebrew/cask/ente
   - homebrew/cask/ente-auth
   - homebrew/cask/font-hack-nerd-font
+  - homebrew/cask/font-jetbrains-mono
+  - homebrew/cask/font-jetbrains-mono-nerd-font
   - homebrew/cask/ghostty
   - homebrew/cask/mailspring
   - homebrew/cask/onlyoffice
   - homebrew/cask/proton-drive
   - homebrew/cask/raycast
   - homebrew/cask/standard-notes
-  - homebrew/cask/tailscale
-  - homebrew/cask/volta
+  - homebrew/cask/tailscale-app
   - htop
   - lazygit
   - neovim
@@ -30,6 +28,7 @@ brew_formula_packages:
   - tldr
   - tmux
   - tursodatabase/tap/turso
+  - volta
   - withgraphite/tap/graphite
   - zsh
 


### PR DESCRIPTION
### TL;DR

Updated Homebrew package list with corrected paths and package changes.

### What changed?

- Moved font packages from cask-fonts to cask directory:
  - `homebrew/cask-fonts/font-jetbrains-mono` → `homebrew/cask/font-jetbrains-mono`
  - `homebrew/cask-fonts/font-jetbrains-mono-nerd-font` → `homebrew/cask/font-jetbrains-mono-nerd-font`
- Renamed `homebrew/cask/tailscale` to `homebrew/cask/tailscale-app`
- Removed `homebrew/cask/emacs` package
- Moved `volta` from cask to formula (removed `homebrew/cask/volta` and added `volta`)

### How to test?

1. Run the package management role with the updated vars file
2. Verify all packages install correctly
3. Confirm that Tailscale installs as `tailscale-app`
4. Check that Volta installs as a formula rather than a cask
5. Verify fonts are correctly installed from the new paths

### Why make this change?

These changes align with Homebrew's current package structure and naming conventions. The Tailscale package was renamed in the Homebrew repository, and Volta is better installed as a formula rather than a cask. Font paths were updated to use the correct repository structure.