### PR TITLE
feat(opencode): add context7 mcp server

### DIFF
--- a/roles/opencode/files/opencode.jsonc
+++ b/roles/opencode/files/opencode.jsonc
@@ -1,4 +1,15 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "theme": "system",
+  "autoupdate": false,
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "ctx7sk-5cb66bd3-9693-4b8a-9039-0f67fe13d359",
+      },
+      "enabled": true,
+    },
+  },
 }


### PR DESCRIPTION
### TL;DR

Added MCP configuration for Context7 integration and disabled auto-updates in OpenCode.

### What changed?

- Added `"autoupdate": false` to disable automatic updates
- Added a new `mcp` configuration section with Context7 remote integration
- Configured the Context7 integration with the appropriate API key and endpoint URL

### How to test?

1. Launch OpenCode after applying this change
2. Verify that Context7 integration is available in the MCP section
3. Confirm that auto-updates are disabled in the settings

### Why make this change?

This change integrates Context7's Machine Control Protocol (MCP) service with OpenCode, allowing users to access Context7's capabilities directly within the application. Auto-updates have been disabled to ensure controlled deployment of new versions in our environment.