### PR TITLE
fix(ghostty): update ghostty config

### DIFF
--- a/roles/ghostty/files/config
+++ b/roles/ghostty/files/config
@@ -4,7 +4,7 @@ font-family = JetBrainsMono Nerd Font Mono
 # Ghostty will round to closest integer pixel value.
 font-size = 14.5
 
-theme = catppuccin-macchiato
+theme = Catppuccin Mocha
 
 background-opacity = 0.8
 background-blur-radius = 20


### PR DESCRIPTION
### TL;DR

Updated Ghostty theme from catppuccin-macchiato to Catppuccin Mocha.

### What changed?

Changed the theme configuration in the Ghostty config file from `catppuccin-macchiato` to `Catppuccin Mocha`. The background opacity and blur settings remain unchanged.

### How to test?

1. Apply the updated config file
2. Launch Ghostty terminal
3. Verify that the terminal now uses the Catppuccin Mocha theme
4. Confirm that the background opacity (0.8) and blur radius (20) still work as expected

### Why make this change?

Catppuccin Mocha offers a darker color palette compared to Macchiato, which may provide better contrast and reduce eye strain, especially when working in low-light environments.