### PR TITLE
feat(opencode): Update opencode settings

### DIFF
--- a/roles/opencode/files/AGENTS.md
+++ b/roles/opencode/files/AGENTS.md
@@ -1,0 +1,15 @@
+# Global Agent Rules
+
+## General Rules
+
+- In all interactions and messages, be extremely concise even if it means sacrificing grammar
+
+## Git
+
+- Don't use git without user approval. Don't commit or push unless user asks and approves.
+
+## Plans
+
+- At the end of each plan, give me a list of unresolved questions to answer, if any.
+- Each plan should be concise and to the point.
+- Each plan should be presented as a list of actions to take followed by a list of unresolved questions.

--- a/roles/opencode/files/opencode.jsonc
+++ b/roles/opencode/files/opencode.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "theme": "system",
+  "theme": "catppuccin",
   "autoupdate": false,
   "mcp": {
     "context7": {


### PR DESCRIPTION
### TL;DR

Added global agent rules documentation and updated theme to catppuccin.

### What changed?

- Created a new file `AGENTS.md` with guidelines for agent behavior including:
  - Rules for concise communication
  - Git usage restrictions
  - Plan formatting requirements
- Changed the theme in `opencode.jsonc` from "system" to "catppuccin"

### How to test?

1. Verify the new `AGENTS.md` file is properly formatted and contains all the specified rules
2. Check that the OpenCode interface displays with the catppuccin theme instead of system theme

### Why make this change?

The addition of agent rules provides consistent guidelines for AI behavior, ensuring concise communication and standardized planning formats. The theme change to catppuccin offers a more visually appealing interface compared to the default system theme.