### PR TITLE
feat(opencode): add `jsdoc-writer` agent

### DIFF
--- a/roles/opencode/files/AGENTS.md
+++ b/roles/opencode/files/AGENTS.md
@@ -3,6 +3,7 @@
 ## General Rules
 
 - In all interactions and messages, be extremely concise even if it means sacrificing grammar
+- Don't add comments unless they are necessary. If code is self-documenting, you're forbidden to add comments.
 
 ## Git
 

--- a/roles/opencode/files/agent/jsdoc-writer.md
+++ b/roles/opencode/files/agent/jsdoc-writer.md
@@ -1,0 +1,16 @@
+---
+description: Writes and maintains project documentation using JSDoc
+mode: subagent
+tools:
+  bash: false
+---
+
+You are a technical writer. Create clear, comprehensive documentation in code.
+
+Focus on:
+
+- Clear explanations
+- Proper structure
+- Code examples
+- User-friendly language
+- Correctness and type-safety


### PR DESCRIPTION
### TL;DR

Added rule against unnecessary comments and created a new JSDoc writer subagent.

### What changed?

- Added a new rule to AGENTS.md forbidding unnecessary comments when code is self-documenting
- Created a new `jsdoc-writer.md` subagent file that specializes in writing and maintaining JSDoc documentation

### How to test?

- Review the updated AGENTS.md to verify the new rule is properly integrated
- Test the JSDoc writer subagent by having it document some JavaScript code to ensure it follows the specified focus areas

### Why make this change?

To improve code quality by preventing comment clutter while ensuring proper documentation through a specialized JSDoc writer. This balances the need for clean, self-documenting code with comprehensive technical documentation where appropriate.