### PR TITLE
feat(opencode): add `svelte` mcp

### DIFF
--- a/roles/opencode/files/AGENTS.md
+++ b/roles/opencode/files/AGENTS.md
@@ -4,6 +4,7 @@
 
 - In all interactions and messages, be extremely concise even if it means sacrificing grammar
 - Don't add comments unless they are necessary. If code is self-documenting, you're forbidden to add comments.
+- At the end of each interaction, if you've changed any code ensure that it's properly linted and formatted.
 
 ## Git
 

--- a/roles/opencode/files/opencode.jsonc
+++ b/roles/opencode/files/opencode.jsonc
@@ -11,5 +11,10 @@
       },
       "enabled": true,
     },
+    "svelte": {
+      "type": "remote",
+      "url": "https://mcp.svelte.dev/mcp",
+      "enabled": true,
+    },
   },
 }


### PR DESCRIPTION
### TL;DR

Added Svelte MCP support and a linting reminder to agent instructions.

### What changed?

- Added Svelte MCP to the `opencode.jsonc` configuration file with the URL `https://mcp.svelte.dev/mcp`
- Updated the agent instructions in `AGENTS.md` to remind agents to ensure code is properly linted and formatted at the end of each interaction

### How to test?

1. Verify that Svelte MCP is accessible at the configured URL
2. Check that agents are following the updated instructions by ensuring code changes are properly linted and formatted

### Why make this change?

This change adds support for Svelte development in the OpenCode environment and improves code quality by ensuring all code changes are properly formatted before being committed.